### PR TITLE
Display energy as joules and power in watts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Environment variables `EMPORIA_USERNAME` and `EMPORIA_PASSWORD` will login too
 - Specify a device to measure with flag `--device` or variable `EMPORIA_DEVICE`
 - Detailed information about this program is included in the README
+- Include the average power used over a command executation in watts
 
 ### Changed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Path to the repository was changed and now it matches
 - Timing outputs are now consistent across operating systems
 - Errors from the provided command are properly propogated
+- Correctly dislpay energy as joules and power as watts
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ mv etime /usr/local/bin
 ```sh
 $ ./etime sleep 12
        12.00 real         0.00 user         0.00 sys
-        9.35 watt       100.0% sure
+      922.63 joules      76.87 watts      100.0% sure
 ```
 
 The first time you run `etime`, you will be prompted to login with your

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The duration of the input command is measured with the built-in `time` command.
 
 Meanings of these measurements are as follows:
 
-- `real`: The actual execution time from start to finish
+- `real`: the actual execution time from start to finish
 - `user`: CPU time spent executing user-mode code for the process
 - `sys`: CPU time spent making system calls in kernel mode
 
@@ -51,8 +51,14 @@ A more detailed explanation can be found in [this StackOverflow answer][time].
 
 ### Energy
 
-The amount of electricity used during the execution of the input command is
-collected from the Smart Plug and displayed in `watt`.
+Measurments of electricity used while executing the input command are collected
+from the Smart Plug.
+
+This usage is shown in the following units:
+
+- `joules`: the total [energy][energy] used during the command duration
+- `watts`: the average [power][power] output over the command duration
+- `sure`: a confidence score for the above values
 
 Results from [the Emporia API][docs] may not always be complete, so missing
 usage is estimated by scaling the average measured energy over the total elapsed
@@ -109,4 +115,6 @@ Environment variables can be used as another way to configure the program:
 [golang]: https://go.dev/dl
 [dashboard]: https://web.emporiaenergy.com/#/home
 [time]: https://stackoverflow.com/a/556411
+[energy]: https://en.wikipedia.org/wiki/Energy
+[power]: https://en.wikipedia.org/wiki/Power_(physics)
 [docs]: https://github.com/magico13/PyEmVue/blob/master/api_docs.md

--- a/internal/terminal/templates.go
+++ b/internal/terminal/templates.go
@@ -70,7 +70,7 @@ Measure the time and energy used while executing a command
 {{ Bold "EXAMPLE" }}
   $ {{ CommandName }} sleep 12
          12.00 real         0.00 user         0.00 sys
-          9.53 watt        61.5%% sure
+        922.63 joules      76.87 watts      100.0%% sure
 
 `
 	if body, err := TemplateBuilder(helpTemplate, nil); err != nil {

--- a/internal/terminal/templates.go
+++ b/internal/terminal/templates.go
@@ -60,12 +60,12 @@ Measure the time and energy used while executing a command
   --password <string>  account password for Emporia
 
 {{ Bold "OUTPUT" }}
-  Command output is printed as specified by the program
+  Command output is printed as specified by the command
   Time and energy usage information is output to stderr
 
-  Time is measured in seconds as defined by the time command
-  Energy is measured in watts and collected from Emporia
-  Sureness is the ratio of recieved-to-expected measurements
+  Time is counted with seconds and measured by the time command
+  Usage is measured by the device and shown in joules and watts
+  Sure is the ratio of recieved-to-expected measurements
 
 {{ Bold "EXAMPLE" }}
   $ {{ CommandName }} sleep 12

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 func formatUsage(results CommandResult) (string, error) {
 	energyTemplate := strings.TrimSpace(`
 {{12 | Time .TimeMeasurement.Command.Real}} real {{12 | Time .TimeMeasurement.Command.User}} user {{12 | Time .TimeMeasurement.Command.Sys}} sys
-{{12 | Value .EnergyResult.Watts}} watt {{11 | Percent .EnergyResult.Sureness}}% sure`)
+{{12 | Value .EnergyResult.Joules}} joules {{10 | Value .EnergyResult.Watts}} watts {{10 | Percent .EnergyResult.Sureness}}% sure`)
 
 	body, err := terminal.TemplateBuilder(energyTemplate, results)
 	if err != nil {

--- a/pkg/emporia/request.go
+++ b/pkg/emporia/request.go
@@ -56,7 +56,7 @@ func (emp *Emporia) CollectEnergyUsage(times times.TimeMeasurement) (energy.Ener
 	}
 
 	var results energy.EnergyResult
-	results = energy.ExtrapolateUsage(chart, times.Elapsed.Seconds())
+	results = energy.ExtrapolateUsage(chart, times.Elapsed)
 
 	// Repeat lookup for unsure results
 	for results.Sureness < confidence {

--- a/pkg/emporia/request.go
+++ b/pkg/emporia/request.go
@@ -55,8 +55,10 @@ func (emp *Emporia) CollectEnergyUsage(times times.TimeMeasurement) (energy.Ener
 		return energy.EnergyResult{}, err
 	}
 
-	var results energy.EnergyResult
-	results = energy.ExtrapolateUsage(chart, times.Elapsed)
+	results := energy.ExtrapolateUsage(energy.EnergyMeasurement{
+		Chart:    chart,
+		Duration: times.Elapsed,
+	})
 
 	// Repeat lookup for unsure results
 	for results.Sureness < confidence {

--- a/pkg/energy/energy.go
+++ b/pkg/energy/energy.go
@@ -16,24 +16,26 @@ func ScaleKWhToWs(kwh float64) float64 {
 
 // ExtrapolateUsage scales the average measured energy rate over the elapsed
 // time to account for missing measurements, returning est. watts and sureness
-func ExtrapolateUsage(measurements []float64, durr float64) EnergyResult {
-	var sum float64 = 0
+func ExtrapolateUsage(measurements []float64, duration float64) EnergyResult {
+	count := float64(len(measurements))
+	sum := 0.0
 	for _, mm := range measurements {
 		sum += mm
 	}
 
-	// cannot estimate an empty measurement
-	measured := float64(len(measurements))
-	if measured == 0 || sum == 0 {
+	if duration == 0 {
+		return EnergyResult{Watts: 0, Sureness: 1}
+	}
+	if count == 0 || sum == 0 {
 		return EnergyResult{Watts: 0, Sureness: 0}
 	}
 
 	// scale the summation across the entire duration
-	estimated := sum * (durr / measured)
+	estimated := sum * (duration / count)
 
 	// calculate the observed-to-expected measurement ratio
-	sureness := measured / durr
-	if measured > durr {
+	sureness := count / duration
+	if count > duration {
 		sureness = 1.0
 	}
 

--- a/pkg/energy/energy.go
+++ b/pkg/energy/energy.go
@@ -1,5 +1,9 @@
 package energy
 
+import (
+	"time"
+)
+
 const HourToSeconds float64 = 3600
 const KiloToUnit float64 = 1000
 
@@ -16,7 +20,8 @@ func ScaleKWhToWs(kwh float64) float64 {
 
 // ExtrapolateUsage scales the average measured energy rate over the elapsed
 // time to account for missing measurements, returning est. watts and sureness
-func ExtrapolateUsage(measurements []float64, duration float64) EnergyResult {
+func ExtrapolateUsage(measurements []float64, duration time.Duration) EnergyResult {
+	seconds := time.Duration.Seconds(duration)
 	count := float64(len(measurements))
 	sum := 0.0
 	for _, mm := range measurements {
@@ -31,11 +36,11 @@ func ExtrapolateUsage(measurements []float64, duration float64) EnergyResult {
 	}
 
 	// scale the summation across the entire duration
-	estimated := sum * (duration / count)
+	estimated := sum * (seconds / count)
 
 	// calculate the observed-to-expected measurement ratio
-	sureness := count / duration
-	if count > duration {
+	sureness := count / seconds
+	if count > seconds {
 		sureness = 1.0
 	}
 

--- a/pkg/energy/energy.go
+++ b/pkg/energy/energy.go
@@ -4,13 +4,24 @@ import (
 	"time"
 )
 
+// HourToSeconds multiplies units of hours to seconds
 const HourToSeconds float64 = 3600
+
+// KiloToUnit multiplies thousands to ones
 const KiloToUnit float64 = 1000
+
+// EnergyMeasurement holds response values of energy usage
+type EnergyMeasurement struct {
+	Chart    []float64     // Chart contains energy measurements as watt seconds
+	Duration time.Duration // Duration is the amount of time used running a command
+}
 
 // EnergyResult contains the calculated energy measurements
 type EnergyResult struct {
-	Watts    float64
-	Sureness float64
+	Joules   float64       // Joules is the total energy used during the duration
+	Watts    float64       // Watts is the average power output over the duration
+	Sureness float64       // Sureness is a confidence score for resulting energy
+	Duration time.Duration // Duration is the amount of time used running a command
 }
 
 // ScaleKWhToWs converts kilowatt-hours to watt-seconds
@@ -18,31 +29,34 @@ func ScaleKWhToWs(kwh float64) float64 {
 	return kwh * KiloToUnit * HourToSeconds
 }
 
-// ExtrapolateUsage scales the average measured energy rate over the elapsed
-// time to account for missing measurements, returning est. watts and sureness
-func ExtrapolateUsage(measurements []float64, duration time.Duration) EnergyResult {
-	seconds := time.Duration.Seconds(duration)
-	count := float64(len(measurements))
-	sum := 0.0
-	for _, mm := range measurements {
-		sum += mm
+// ExtrapolateUsage scales the measured energy response over the actual duration
+func ExtrapolateUsage(measurements EnergyMeasurement) EnergyResult {
+	actualSeconds := measurements.Duration.Seconds()
+	measuredSeconds := float64(len(measurements.Chart))
+	measuredJoules := 0.0
+	for _, measuredWattSecond := range measurements.Chart {
+		measuredJoules += measuredWattSecond
+	}
+	if actualSeconds == 0.0 {
+		return EnergyResult{Joules: 0, Watts: 0, Sureness: 1}
+	}
+	if measuredSeconds == 0 || measuredJoules == 0 {
+		return EnergyResult{Joules: 0, Watts: 0, Sureness: 0}
 	}
 
-	if duration == 0 {
-		return EnergyResult{Watts: 0, Sureness: 1}
-	}
-	if count == 0 || sum == 0 {
-		return EnergyResult{Watts: 0, Sureness: 0}
-	}
+	// Scale the measured summation across the actual duration
+	estimatedJoules := measuredJoules * (actualSeconds / measuredSeconds)
+	estimatedWatts := estimatedJoules / actualSeconds
 
-	// scale the summation across the entire duration
-	estimated := sum * (seconds / count)
-
-	// calculate the observed-to-expected measurement ratio
-	sureness := count / seconds
-	if count > seconds {
+	// Calculate the observed-to-expected measurement ratio
+	sureness := measuredSeconds / actualSeconds
+	if measuredSeconds > actualSeconds {
 		sureness = 1.0
 	}
 
-	return EnergyResult{Watts: estimated, Sureness: sureness}
+	return EnergyResult{
+		Joules:   estimatedJoules,
+		Watts:    estimatedWatts,
+		Sureness: sureness,
+	}
 }

--- a/pkg/energy/energy_test.go
+++ b/pkg/energy/energy_test.go
@@ -94,14 +94,14 @@ func TestExtrapolateUsage(t *testing.T) {
 	for _, tt := range tests {
 		actual := ExtrapolateUsage(tt.Measurements, tt.Duration)
 		if tt.ExpectedResult.Watts != actual.Watts {
-			t.Fatalf("An unexpected energy estimation was found!\nTEST: '%s'\nEXPECT: %8f\nACTUAL: %8f",
+			t.Fatalf("An unexpected watt estimation was found!\nFAILED: '%s'\nEXPECT: %8f\nACTUAL: %8f",
 				tt.Title,
 				tt.ExpectedResult.Watts,
 				actual.Watts,
 			)
 		}
 		if tt.ExpectedResult.Sureness != actual.Sureness {
-			t.Fatalf("An unexpected sureness score was found!\nTEST: '%s'\nEXPECT: %8f\nACTUAL: %8f",
+			t.Fatalf("An unexpected sureness score was found!\nFAILED: '%s'\nEXPECT: %8f\nACTUAL: %8f",
 				tt.Title,
 				tt.ExpectedResult.Sureness,
 				actual.Sureness,

--- a/pkg/energy/energy_test.go
+++ b/pkg/energy/energy_test.go
@@ -43,9 +43,15 @@ func TestExtrapolateUsage(t *testing.T) {
 	tests := []struct {
 		Title          string
 		Measurements   []float64
-		Durration      float64
+		Duration       float64
 		ExpectedResult EnergyResult
 	}{
+		{
+			"handle the measurements of instant commands",
+			[]float64{0},
+			0,
+			EnergyResult{Watts: 0, Sureness: 1},
+		},
 		{
 			"return unsure results if no measurements are returned",
 			[]float64{},

--- a/pkg/energy/energy_test.go
+++ b/pkg/energy/energy_test.go
@@ -2,6 +2,7 @@ package energy
 
 import (
 	"testing"
+	"time"
 )
 
 func TestScaleKWhToWs(t *testing.T) {
@@ -43,55 +44,55 @@ func TestExtrapolateUsage(t *testing.T) {
 	tests := []struct {
 		Title          string
 		Measurements   []float64
-		Duration       float64
+		Duration       time.Duration
 		ExpectedResult EnergyResult
 	}{
 		{
 			"handle the measurements of instant commands",
 			[]float64{0},
-			0,
+			time.Duration(0 * float64(time.Second)),
 			EnergyResult{Watts: 0, Sureness: 1},
 		},
 		{
 			"return unsure results if no measurements are returned",
 			[]float64{},
-			3,
+			time.Duration(3 * float64(time.Second)),
 			EnergyResult{Watts: 0, Sureness: 0},
 		},
 		{
 			"return unsure results if all measurements are zero",
 			[]float64{0, 0, 0},
-			3,
+			time.Duration(3 * float64(time.Second)),
 			EnergyResult{Watts: 0, Sureness: 0},
 		},
 		{
 			"confidently compute results for complete measurements",
 			[]float64{3.64, 4.2, 2}, // sum=9.84, avg=3.28
-			3,
+			time.Duration(3 * float64(time.Second)),
 			EnergyResult{Watts: 9.84, Sureness: 1},
 		},
 		{
 			"extrapolate a missing second of measured results",
 			[]float64{3, 4, 6, 3}, // sum=16, avg=4
-			5,
+			time.Duration(5 * float64(time.Second)),
 			EnergyResult{Watts: 20, Sureness: 0.8},
 		},
 		{
 			"extrapolate a half second of undermeasured results",
 			[]float64{3, 4, 6, 3}, // sum=16, avg=4
-			4.5,
+			time.Duration(4.5 * float64(time.Second)),
 			EnergyResult{Watts: 18, Sureness: 4 / 4.5},
 		},
 		{
 			"extrapolate a half second of overmeasured results",
 			[]float64{3, 4, 6, 3, 4}, // sum=20, avg=4
-			4.5,
+			time.Duration(4.5 * float64(time.Second)),
 			EnergyResult{Watts: 18, Sureness: 1},
 		},
 	}
 
 	for _, tt := range tests {
-		actual := ExtrapolateUsage(tt.Measurements, tt.Durration)
+		actual := ExtrapolateUsage(tt.Measurements, tt.Duration)
 		if tt.ExpectedResult.Watts != actual.Watts {
 			t.Fatalf("An unexpected energy estimation was found!\nTEST: '%s'\nEXPECT: %8f\nACTUAL: %8f",
 				tt.Title,

--- a/pkg/energy/energy_test.go
+++ b/pkg/energy/energy_test.go
@@ -51,48 +51,58 @@ func TestExtrapolateUsage(t *testing.T) {
 			"handle the measurements of instant commands",
 			[]float64{0},
 			time.Duration(0 * float64(time.Second)),
-			EnergyResult{Watts: 0, Sureness: 1},
+			EnergyResult{Joules: 0, Watts: 0, Sureness: 1},
 		},
 		{
 			"return unsure results if no measurements are returned",
 			[]float64{},
 			time.Duration(3 * float64(time.Second)),
-			EnergyResult{Watts: 0, Sureness: 0},
+			EnergyResult{Joules: 0, Watts: 0, Sureness: 0},
 		},
 		{
 			"return unsure results if all measurements are zero",
 			[]float64{0, 0, 0},
 			time.Duration(3 * float64(time.Second)),
-			EnergyResult{Watts: 0, Sureness: 0},
+			EnergyResult{Joules: 0, Watts: 0, Sureness: 0},
 		},
 		{
 			"confidently compute results for complete measurements",
 			[]float64{3.64, 4.2, 2}, // sum=9.84, avg=3.28
 			time.Duration(3 * float64(time.Second)),
-			EnergyResult{Watts: 9.84, Sureness: 1},
+			EnergyResult{Joules: 9.84, Watts: 3.28, Sureness: 1},
 		},
 		{
 			"extrapolate a missing second of measured results",
 			[]float64{3, 4, 6, 3}, // sum=16, avg=4
 			time.Duration(5 * float64(time.Second)),
-			EnergyResult{Watts: 20, Sureness: 0.8},
+			EnergyResult{Joules: 20, Watts: 4, Sureness: 0.8},
 		},
 		{
 			"extrapolate a half second of undermeasured results",
 			[]float64{3, 4, 6, 3}, // sum=16, avg=4
 			time.Duration(4.5 * float64(time.Second)),
-			EnergyResult{Watts: 18, Sureness: 4 / 4.5},
+			EnergyResult{Joules: 18, Watts: 4, Sureness: 4 / 4.5},
 		},
 		{
 			"extrapolate a half second of overmeasured results",
 			[]float64{3, 4, 6, 3, 4}, // sum=20, avg=4
 			time.Duration(4.5 * float64(time.Second)),
-			EnergyResult{Watts: 18, Sureness: 1},
+			EnergyResult{Joules: 18, Watts: 4, Sureness: 1},
 		},
 	}
 
 	for _, tt := range tests {
-		actual := ExtrapolateUsage(tt.Measurements, tt.Duration)
+		actual := ExtrapolateUsage(EnergyMeasurement{
+			Chart:    tt.Measurements,
+			Duration: tt.Duration,
+		})
+		if tt.ExpectedResult.Joules != actual.Joules {
+			t.Fatalf("An unexpected joule estimation was found!\nFAILED: '%s'\nEXPECT: %8f\nACTUAL: %8f",
+				tt.Title,
+				tt.ExpectedResult.Joules,
+				actual.Joules,
+			)
+		}
 		if tt.ExpectedResult.Watts != actual.Watts {
 			t.Fatalf("An unexpected watt estimation was found!\nFAILED: '%s'\nEXPECT: %8f\nACTUAL: %8f",
 				tt.Title,


### PR DESCRIPTION
the measurements from emporia are converted to watt seconds before any estimations. previously these watt seconds were summed and shown as `watts` when these are actually `joules` – watts measure power and joules for energy.