### PR TITLE
Convert time measurement outputs to float64 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump Go version to 1.20
 - Plainly use the /usr/bin/time command instead of a generic time
+- Parse the `time` output for measurements represented as float64 seconds
 
 ### Fixed
 

--- a/internal/terminal/templates.go
+++ b/internal/terminal/templates.go
@@ -20,8 +20,8 @@ func TemplateBuilder(templateStr string, body interface{}) (string, error) {
 		"Percent": func(f float64, spacing int) string {
 			return fmt.Sprintf("%*.1f", spacing, f*100)
 		},
-		"Time": func(f string, spacing int) string {
-			return fmt.Sprintf("%*s", spacing, f)
+		"Time": func(f float64, spacing int) string {
+			return fmt.Sprintf("%*.2f", spacing, f)
 		},
 		"Value": func(f float64, spacing int) string {
 			return fmt.Sprintf("%*.2f", spacing, f)

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zimeg/emporia-time/pkg/times"
 )
 
-func TestFormatUsage_Regular(t *testing.T) {
+func TestFormatUsage_Formatted(t *testing.T) {
 	tests := []struct {
 		Title  string
 		Result CommandResult
@@ -19,9 +19,9 @@ func TestFormatUsage_Regular(t *testing.T) {
 			CommandResult{
 				TimeMeasurement: times.TimeMeasurement{
 					Command: times.CommandTime{
-						Real: "0.00",
-						User: "0.00",
-						Sys:  "0.00",
+						Real: 0.0,
+						User: 0.0,
+						Sys:  0.0,
 					},
 				},
 				EnergyResult: energy.EnergyResult{
@@ -36,15 +36,15 @@ func TestFormatUsage_Regular(t *testing.T) {
 			CommandResult{
 				TimeMeasurement: times.TimeMeasurement{
 					Command: times.CommandTime{
-						Real: "4.00",
-						User: "2.10",
-						Sys:  "1.40",
+						Real: 4.0,
+						User: 2.1,
+						Sys:  1.4,
 					},
 				},
 				EnergyResult: energy.EnergyResult{
 					Joules:   12.00,
 					Watts:    3.00,
-					Sureness: .9620,
+					Sureness: 0.9620,
 				},
 			},
 		},
@@ -56,13 +56,13 @@ func TestFormatUsage_Regular(t *testing.T) {
 			t.Error("An unexpected error was encountered while formatting!")
 		}
 
-		if !strings.Contains(output, fmt.Sprintf(" %s real", tt.Result.TimeMeasurement.Command.Real)) {
+		if !strings.Contains(output, fmt.Sprintf(" %.2f real", tt.Result.TimeMeasurement.Command.Real)) {
 			t.Error("The `real` measurement is missing in the output!")
 		}
-		if !strings.Contains(output, fmt.Sprintf(" %s user", tt.Result.TimeMeasurement.Command.User)) {
+		if !strings.Contains(output, fmt.Sprintf(" %.2f user", tt.Result.TimeMeasurement.Command.User)) {
 			t.Error("The `user` measurement is missing in the output!")
 		}
-		if !strings.Contains(output, fmt.Sprintf(" %s sys", tt.Result.TimeMeasurement.Command.Sys)) {
+		if !strings.Contains(output, fmt.Sprintf(" %.2f sys", tt.Result.TimeMeasurement.Command.Sys)) {
 			t.Error("The `sys` measurement is missing in the output!")
 		}
 		if !strings.Contains(output, fmt.Sprintf(" %.2f joules", tt.Result.EnergyResult.Joules)) {
@@ -87,9 +87,9 @@ func TestFormatUsage_Portable(t *testing.T) {
 			CommandResult{
 				TimeMeasurement: times.TimeMeasurement{
 					Command: times.CommandTime{
-						Real: "0.00",
-						User: "0.00",
-						Sys:  "0.00",
+						Real: 0.0,
+						User: 0.0,
+						Sys:  0.0,
 					},
 				},
 				EnergyResult: energy.EnergyResult{
@@ -104,15 +104,15 @@ func TestFormatUsage_Portable(t *testing.T) {
 			CommandResult{
 				TimeMeasurement: times.TimeMeasurement{
 					Command: times.CommandTime{
-						Real: "4.00",
-						User: "2.10",
-						Sys:  "1.40",
+						Real: 4.0,
+						User: 2.1,
+						Sys:  1.4,
 					},
 				},
 				EnergyResult: energy.EnergyResult{
 					Joules:   12.00,
 					Watts:    3.00,
-					Sureness: .9620,
+					Sureness: 0.9620,
 				},
 			},
 		},
@@ -134,11 +134,11 @@ func TestFormatUsage_Portable(t *testing.T) {
 		)
 		for _, line := range strings.Split(output, "\n") {
 			switch line {
-			case fmt.Sprintf("%s real", tt.Result.TimeMeasurement.Command.Real):
+			case fmt.Sprintf("%.2f real", tt.Result.TimeMeasurement.Command.Real):
 				realTimeCount += 1
-			case fmt.Sprintf("%s user", tt.Result.TimeMeasurement.Command.User):
+			case fmt.Sprintf("%.2f user", tt.Result.TimeMeasurement.Command.User):
 				userTimeCount += 1
-			case fmt.Sprintf("%s sys", tt.Result.TimeMeasurement.Command.Sys):
+			case fmt.Sprintf("%.2f sys", tt.Result.TimeMeasurement.Command.Sys):
 				sysTimeCount += 1
 			case fmt.Sprintf("%.2f joules", tt.Result.EnergyResult.Joules):
 				joulesCount += 1

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,9 +24,9 @@ type TimeMeasurement struct {
 
 // CommandTime contains the values from the time command
 type CommandTime struct {
-	Real string
-	User string
-	Sys  string
+	Real float64
+	User float64
+	Sys  float64
 }
 
 // TimeExec performs the command and prints outputs while measuring timing
@@ -63,12 +64,13 @@ func TimeExec(command terminal.Command) (TimeMeasurement, error) {
 
 // parseTimeResults extracts the time information from output
 func parseTimeResults(output bytes.Buffer) (CommandTime, bytes.Buffer, error) {
-	times := CommandTime{}
 	lines := strings.Split(output.String(), "\n")
 
 	var cmd []string
 	var userTimeFound, sysTimeFound, realTimeFound bool
 	var userTimeIndex, sysTimeIndex, realTimeIndex int
+	var userTimeValue, sysTimeValue, realTimeValue string
+	var userTimeFloat, sysTimeFloat, realTimeFloat float64
 	for ii, line := range lines {
 		fields := strings.Fields(line)
 		matched := false
@@ -78,20 +80,20 @@ func parseTimeResults(output bytes.Buffer) (CommandTime, bytes.Buffer, error) {
 			value := fields[1]
 			switch name {
 			case "user":
-				times.User = trimTimeValue(value)
 				matched = true
 				userTimeFound = true
 				userTimeIndex = ii
+				userTimeValue = value
 			case "sys":
-				times.Sys = trimTimeValue(value)
 				matched = true
 				sysTimeFound = true
 				sysTimeIndex = ii
+				sysTimeValue = value
 			case "real":
-				times.Real = trimTimeValue(value)
 				matched = true
 				realTimeFound = true
 				realTimeIndex = ii
+				realTimeValue = value
 			}
 		}
 		if !matched {
@@ -114,17 +116,29 @@ func parseTimeResults(output bytes.Buffer) (CommandTime, bytes.Buffer, error) {
 		buff.Truncate(buff.Len() - 1)
 	}
 
+	var err error
 	if !userTimeFound || !sysTimeFound || !realTimeFound {
-		return times, buff, errors.New("A time value is missing in the output!")
+		return CommandTime{}, buff, errors.New("A time value is missing in the output!")
+	}
+	if userTimeFloat, err = parseTimeValue(userTimeValue); err != nil {
+		return CommandTime{}, buff, errors.New("Failed to parse the user time value!")
+	}
+	if sysTimeFloat, err = parseTimeValue(sysTimeValue); err != nil {
+		return CommandTime{}, buff, errors.New("Failed to parse the sys time value!")
+	}
+	if realTimeFloat, err = parseTimeValue(realTimeValue); err != nil {
+		return CommandTime{}, buff, errors.New("Failed to parse the real time value!")
+	}
+
+	times := CommandTime{
+		User: userTimeFloat,
+		Sys:  sysTimeFloat,
+		Real: realTimeFloat,
 	}
 	return times, buff, nil
 }
 
-// trimTimeValue removes most leading zeros
-func trimTimeValue(value string) string {
-	trim := strings.TrimLeft(value, "0:")
-	if strings.Index(trim, ".") == 0 {
-		trim = "0" + trim
-	}
-	return trim
+// parseTimeValue converts a string to a float64
+func parseTimeValue(value string) (float64, error) {
+	return strconv.ParseFloat(value, 64)
 }

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -57,7 +57,9 @@ func TimeExec(command terminal.Command) (TimeMeasurement, error) {
 	times.Command = results
 
 	fmt.Printf("%s", stdout.String())
-	fmt.Fprintf(os.Stderr, "%s", stderr.String())
+	if stderr.Len() > 0 {
+		fmt.Fprintf(os.Stderr, "%s\n", stderr.String())
+	}
 
 	return times, err
 }

--- a/pkg/times/time_test.go
+++ b/pkg/times/time_test.go
@@ -2,7 +2,6 @@ package times
 
 import (
 	"bytes"
-	"errors"
 	"strings"
 	"testing"
 )
@@ -47,18 +46,6 @@ func TestParseTimeResults(t *testing.T) {
 				"example command output!",
 			},
 			nil,
-		},
-		{
-			"error and return command outputs if a time value is missing",
-			[]string{
-				"something strange happened here...",
-				"sys 6000.00",
-			},
-			CommandTime{},
-			[]string{
-				"something strange happened here...",
-			},
-			errors.New("A time value is missing in the output!"),
 		},
 		{
 			"prefer the latest outputs for timing information",

--- a/pkg/times/time_test.go
+++ b/pkg/times/time_test.go
@@ -149,7 +149,7 @@ func TestParseTimeValue(t *testing.T) {
 			[]float64{2.0, 4.0, 6.02, 12.8, 6.1},
 		},
 		{
-			"parse times greater than seconds",
+			"parse times greater than sixty seconds",
 			[]string{"573.66", "261.01", "850.70", "86405.12"},
 			[]float64{573.66, 261.01, 850.7, 86405.12},
 		},


### PR DESCRIPTION
note: using the `-p` flag with `/usr/bin/time` outputs measurements in seconds only

another note: all three measurements (`real`, `user`, `sys`) are now always expected. something has gone pretty wrong if these don't show...