### PR TITLE
fix: return errors found when parsing flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse the provided help flag to display a helpful message
 - Return the actual error that happens when building templates
 - Avoid a panic when no command arguments are provided
+- Output errors from parsing flags in a more clear manner
 
 ### Maintenance
 

--- a/cmd/etime.go
+++ b/cmd/etime.go
@@ -18,8 +18,8 @@ type CommandResult struct {
 
 // Setup prepares the command and client with provided inputs
 func Setup(arguments []string) (command program.Command, client emporia.Emporia, err error) {
-	command = program.ParseFlags(arguments)
-	if command.Flags.Help {
+	command, err = program.ParseFlags(arguments)
+	if err != nil || command.Flags.Help {
 		return command, client, err
 	}
 	if config, err := emporia.SetupConfig(command.Flags); err != nil {

--- a/internal/program/flags.go
+++ b/internal/program/flags.go
@@ -1,9 +1,8 @@
 package program
 
 import (
+	"bytes"
 	"flag"
-
-	"github.com/zimeg/emporia-time/internal/display/templates"
 )
 
 // Flags holds command line flags specific to etime
@@ -22,8 +21,8 @@ type Command struct {
 }
 
 // ParseFlags prepares the command using provided arguments
-func ParseFlags(arguments []string) Command {
-	var flagset flag.FlagSet
+func ParseFlags(arguments []string) (Command, error) {
+	var flagset = flag.NewFlagSet("etime", flag.ContinueOnError)
 	var flags Flags
 
 	flagset.BoolVar(&flags.Help, "h", false, "display this very informative message")
@@ -35,11 +34,14 @@ func ParseFlags(arguments []string) Command {
 	flagset.StringVar(&flags.Password, "password", "", "account password for Emporia")
 	flagset.StringVar(&flags.Username, "username", "", "account username for Emporia")
 
-	flagset.Usage = templates.PrintHelpMessage
-	flagset.Parse(arguments[1:])
+	flagset.SetOutput(&bytes.Buffer{})
+	err := flagset.Parse(arguments[1:])
+	if err != nil {
+		return Command{}, err
+	}
 	commandArgs := flagset.Args()
 	if len(commandArgs) <= 0 {
 		flags.Help = true
 	}
-	return Command{Args: commandArgs, Flags: flags}
+	return Command{Args: commandArgs, Flags: flags}, nil
 }


### PR DESCRIPTION
<details>
<summary>before</summary>

```sh
$ ./etime -h=2
invalid boolean value "2" for -h: parse error
Measure the time and energy used while executing a command

USAGE
  ./etime [flags] <command> [args]

DESCRIPTION
  flags    optional flags to provide this program
  command  the program to execute and measure
  args     optional arguments for the command

FLAGS
  -h, --help           display this very informative message
  -p, --portable       output measurements on separate lines
  --device <string>    name or ID of the smart plug to measure
  --username <string>  account username for Emporia
  --password <string>  account password for Emporia

OUTPUT
  Command output is printed as specified by the command
  Time and energy usage information is output to stderr

  Time is counted with seconds and measured by the time command
  Usage is measured by the device and shown in joules and watts
  Sure is the ratio of recieved-to-expected measurements

EXAMPLE
  $ ./etime sleep 12
         12.00 real         0.00 user         0.00 sys
        922.63 joules      76.87 watts      100.0% sure

Measure the time and energy used while executing a command

USAGE
  ./etime [flags] <command> [args]

DESCRIPTION
  flags    optional flags to provide this program
  command  the program to execute and measure
  args     optional arguments for the command

FLAGS
  -h, --help           display this very informative message
  -p, --portable       output measurements on separate lines
  --device <string>    name or ID of the smart plug to measure
  --username <string>  account username for Emporia
  --password <string>  account password for Emporia

OUTPUT
  Command output is printed as specified by the command
  Time and energy usage information is output to stderr

  Time is counted with seconds and measured by the time command
  Usage is measured by the device and shown in joules and watts
  Sure is the ratio of recieved-to-expected measurements

EXAMPLE
  $ ./etime sleep 12
         12.00 real         0.00 user         0.00 sys
        922.63 joules      76.87 watts      100.0% sure

```

</details>

<details>
<summary>after</summary>

```sh
$ ./etime -h=2
2024/01/14 16:46:03 Error: invalid boolean value "2" for -h: parse error
```

</details>