### PR TITLE
fix: stream outputs in an unbuffered manner as output happens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Print the current build version with a `--verison` flag
 
+### Fixed
+
+- Output outputs in an unbuffered manner as output happens
+
 ### Maintenance
 
 - Setup a Nix flake for more consistent developments

--- a/pkg/times/stopwatch.go
+++ b/pkg/times/stopwatch.go
@@ -3,6 +3,7 @@ package times
 import (
 	"bytes"
 	"errors"
+	"io"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -14,7 +15,7 @@ import (
 type bufferWriter struct {
 	bounds string
 	buff   *bytes.Buffer
-	std    *os.File
+	std    io.Writer
 	stored bool
 }
 

--- a/pkg/times/stopwatch.go
+++ b/pkg/times/stopwatch.go
@@ -1,0 +1,69 @@
+package times
+
+import (
+	"bytes"
+	"errors"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// bufferWriter contains two writers to write to and a bounds for toggles
+type bufferWriter struct {
+	bounds string
+	buff   *bytes.Buffer
+	std    *os.File
+	stored bool
+}
+
+// Write writes to the stream until bounds is reached then writes to buffer
+func (bw *bufferWriter) Write(p []byte) (int, error) {
+	if string(p) == bw.bounds {
+		bw.stored = true
+		return len(bw.bounds), nil
+	}
+	if bw.stored {
+		return bw.buff.Write(p)
+	} else {
+		return bw.std.Write(p)
+	}
+}
+
+// timerCommand forms the command struct for a timer to be parsed
+func timerCommand(command []string, stderr bufferWriter) *exec.Cmd {
+	timeShell := []string{
+		strings.Join(command, " "),
+		"&&",
+		"1>&2",
+		"echo",
+		stderr.bounds,
+	}
+	timeArgs := []string{
+		"-p",
+		"sh",
+		"-c",
+		strings.Join(timeShell, " "),
+	}
+	cmd := exec.Command("/usr/bin/time", timeArgs...)
+	if errors.Is(cmd.Err, exec.ErrDot) {
+		cmd.Err = nil
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = &stderr
+	return cmd
+}
+
+// makeBounds creates a random string to denote the end of command output
+func makeBounds() string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	const size = 64
+	var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+	var bounds strings.Builder
+	for i := 0; i < size; i++ {
+		bounds.WriteByte(charset[random.Intn(len(charset))])
+	}
+	bounds.WriteByte('\n')
+	return bounds.String()
+}

--- a/pkg/times/stopwatch_test.go
+++ b/pkg/times/stopwatch_test.go
@@ -50,3 +50,19 @@ func TestBufferWriter(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeBounds(t *testing.T) {
+	t.Run("bounds are different between runs", func(t *testing.T) {
+		bounds1 := makeBounds()
+		bounds2 := makeBounds()
+		assert.NotEqual(t, bounds1, bounds2)
+	})
+	t.Run("bounds are somewhat long", func(t *testing.T) {
+		bounds := makeBounds()
+		assert.Greater(t, len(bounds), 40)
+	})
+	t.Run("bounds ends in a newline", func(t *testing.T) {
+		bounds := makeBounds()
+		assert.Equal(t, len(bounds)-1, len(strings.TrimRight(bounds, "\n")))
+	})
+}

--- a/pkg/times/stopwatch_test.go
+++ b/pkg/times/stopwatch_test.go
@@ -1,0 +1,52 @@
+package times
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufferWriter(t *testing.T) {
+	tests := map[string]struct {
+		bounds       string
+		output       []string
+		expectedBuff []string
+		expectedStd  []string
+	}{
+		"outputs are split between buff and std": {
+			bounds: "xoxoxox",
+			output: []string{
+				"something command related",
+				"that spans multiple lines",
+				"xoxoxox",
+				"information from the time",
+			},
+			expectedStd: []string{
+				"something command related",
+				"that spans multiple lines",
+			},
+			expectedBuff: []string{
+				"information from the time",
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			std := &bytes.Buffer{}
+			bw := bufferWriter{
+				bounds: tt.bounds,
+				buff:   &bytes.Buffer{},
+				std:    std,
+			}
+			for _, line := range tt.output {
+				n, err := bw.Write([]byte(line))
+				assert.NoError(t, err)
+				assert.Equal(t, len(line), n)
+			}
+			assert.Equal(t, strings.Join(tt.expectedStd, ""), std.String())
+			assert.Equal(t, strings.Join(tt.expectedBuff, ""), bw.buff.String())
+		})
+	}
+}

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -47,7 +47,6 @@ func (times TimeMeasurement) GetSys() float64 {
 // TimeExec performs the command and prints outputs while measuring timing
 func TimeExec(command program.Command) (TimeMeasurement, error) {
 	var times TimeMeasurement
-	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
 	timeFlags := []string{"-p"}
@@ -57,7 +56,7 @@ func TimeExec(command program.Command) (TimeMeasurement, error) {
 	if errors.Is(cmd.Err, exec.ErrDot) {
 		cmd.Err = nil
 	}
-	cmd.Stdout = &stdout
+	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stderr
 
 	times.Start = time.Now().UTC()
@@ -71,7 +70,6 @@ func TimeExec(command program.Command) (TimeMeasurement, error) {
 	}
 	times.Command = results
 
-	fmt.Printf("%s", stdout.String())
 	if stderr.Len() > 0 {
 		fmt.Fprintf(os.Stderr, "%s\n", stderr.String())
 	}

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -3,10 +3,8 @@ package times
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -46,76 +44,50 @@ func (times TimeMeasurement) GetSys() float64 {
 
 // TimeExec performs the command and prints outputs while measuring timing
 func TimeExec(command program.Command) (TimeMeasurement, error) {
-	var times TimeMeasurement
-	var stderr bytes.Buffer
-
-	timeFlags := []string{"-p"}
-	timeArgs := append(timeFlags, command.Args...)
-
-	cmd := exec.Command("/usr/bin/time", timeArgs...)
-	if errors.Is(cmd.Err, exec.ErrDot) {
-		cmd.Err = nil
+	times := TimeMeasurement{}
+	stderr := bufferWriter{
+		buff:   &bytes.Buffer{},
+		std:    os.Stderr,
+		bounds: makeBounds(),
 	}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = &stderr
 
+	cmd := timerCommand(command.Args, stderr)
 	times.Start = time.Now().UTC()
 	err := cmd.Run()
 	times.End = time.Now().UTC()
-	times.Elapsed = times.End.Sub(times.Start)
 
-	results, stderr, warning := parseTimeResults(stderr)
+	results, warning := parseTimeResults(stderr.buff.String())
 	if warning != nil {
 		log.Printf("Warning: %s", warning)
 	}
+	times.Elapsed = times.End.Sub(times.Start)
 	times.Command = results
-
-	if stderr.Len() > 0 {
-		fmt.Fprintf(os.Stderr, "%s\n", stderr.String())
-	}
 
 	return times, err
 }
 
-// splitBuffer separates the command output from times
-func splitBuffer(buff bytes.Buffer) (command, times []string) {
-	output := buff.String()
-	trimmed := strings.TrimRight(output, "\n")
-	lines := strings.Split(trimmed, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		times = append([]string{lines[i]}, times...)
-		if strings.Contains(lines[i], "real") {
-			command = lines[:i]
-			break
-		}
-	}
-	return command, times
-}
-
 // parseTimeResults extracts the time information from output
-func parseTimeResults(output bytes.Buffer) (times CommandTime, buff bytes.Buffer, err error) {
-	commandLines, timeLines := splitBuffer(output)
-	for _, line := range timeLines {
+func parseTimeResults(output string) (times CommandTime, err error) {
+	lines := strings.TrimSpace(output)
+	for _, line := range strings.Split(lines, "\n") {
 		fields := strings.Fields(line)
 		measurement, value := fields[0], fields[1]
 		switch measurement {
 		case "real":
 			if times.Real, err = parseTimeValue(value); err != nil {
-				return times, buff, errors.New("Failed to parse the real time value!")
+				return times, errors.New("Failed to parse the real time value!")
 			}
 		case "user":
 			if times.User, err = parseTimeValue(value); err != nil {
-				return times, buff, errors.New("Failed to parse the user time value!")
+				return times, errors.New("Failed to parse the user time value!")
 			}
 		case "sys":
 			if times.Sys, err = parseTimeValue(value); err != nil {
-				return times, buff, errors.New("Failed to parse the sys time value!")
+				return times, errors.New("Failed to parse the sys time value!")
 			}
 		}
 	}
-	command := strings.Join(commandLines, "\n")
-	buff.WriteString(command)
-	return times, buff, err
+	return times, err
 }
 
 // parseTimeValue converts a string to a float64

--- a/pkg/times/time_test.go
+++ b/pkg/times/time_test.go
@@ -1,7 +1,6 @@
 package times
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
@@ -10,110 +9,30 @@ import (
 
 func TestParseTimeResults(t *testing.T) {
 	tests := map[string]struct {
-		Output    []string
-		Times     CommandTime
-		CmdOutput []string
-		Error     error
+		Output []string
+		Times  CommandTime
+		Error  error
 	}{
-		"check a command like sleep without any outputs": {
+		"parse the portable output of the time command": {
 			[]string{
-				"real 1.00",
-				"user 1.00",
-				"sys 1.00",
+				"real 6.00",
+				"user 2.20",
+				"sys 3.80",
 			},
 			CommandTime{
-				Real: 1.0,
-				User: 1.0,
-				Sys:  1.0,
-			},
-			[]string{},
-			nil,
-		},
-		"capture and remove time values from the output": {
-			[]string{
-				"example command output!",
-				"real 3754.56",
-				"user 1301.21",
-				"sys 3.24",
-			},
-			CommandTime{
-				Real: 3754.56,
-				User: 1301.21,
-				Sys:  3.24,
-			},
-			[]string{
-				"example command output!",
-			},
-			nil,
-		},
-		"prefer the latest outputs for timing information": {
-			[]string{
-				"this command outputs something familiar",
-				"real 3.00",
-				"user 3.00",
-				"sys 3.00",
-				"but suppose that was hardcoded!",
-				"the real output now follows",
-				"real 240.00",
-				"user 8.00",
-				"sys 12.00",
-			},
-			CommandTime{
-				Real: 240.0,
-				User: 8.0,
-				Sys:  12.0,
-			},
-			[]string{
-				"this command outputs something familiar",
-				"real 3.00",
-				"user 3.00",
-				"sys 3.00",
-				"but suppose that was hardcoded!",
-				"the real output now follows",
-			},
-			nil,
-		},
-		"ensure the parser doesnt break on unexpected values": {
-			[]string{
-				"gathering example account information",
-				"user goatish_burr",
-				"real true",
-				"sys mountains",
-				"real 240.00",
-				"user 8.05",
-				"sys 12.00",
-			},
-			CommandTime{
-				Real: 240.0,
-				User: 8.05,
-				Sys:  12.0,
-			},
-			[]string{
-				"gathering example account information",
-				"user goatish_burr",
-				"real true",
-				"sys mountains",
+				Real: 6.0,
+				User: 2.2,
+				Sys:  3.8,
 			},
 			nil,
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			buff := bytes.NewBufferString(strings.Join(tt.Output, "\n"))
-			stdout := bytes.NewBufferString(strings.Join(tt.CmdOutput, "\n"))
-			times, cmd, err := parseTimeResults(*buff)
-			if tt.Error != nil {
-				assert.Error(t, err)
-				assert.Equal(t, tt.Error, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.Times, times)
-				if len(stdout.Bytes()) != 0 {
-					assert.Equal(t, stdout.Bytes(), cmd.Bytes())
-				} else {
-					assert.Nil(t, cmd.Bytes())
-				}
-			}
+			output := strings.Join(tt.Output, "\n")
+			times, err := parseTimeResults(output)
+			assert.Equal(t, tt.Error, err)
+			assert.Equal(t, tt.Times, times)
 		})
 	}
 }


### PR DESCRIPTION
right now all outputs are kept in a buffer and output only when the command finishes. this is to catch the output times from the `/usr/bin/time` command, but isn't ideal.

these changes stream the outputs as the output happens. it also unlocks interactive programs and scripts - programs like `vim`. calling this a `major` change since outputs might change!

### preview

```sh
#!/bin/bash

for i in {1..5}
do
    echo "waiting"
    echo "paused" >&2
    sleep 1
done
```

#### current behavior

https://github.com/zimeg/emporia-time/assets/18134219/59e4e28d-3281-414b-8565-d1c451b0243e

#### updated behavior

https://github.com/zimeg/emporia-time/assets/18134219/377eb479-3086-4947-9af1-a20edce7f94d