### PR TITLE
ci: checkout the entire git history for ci tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,10 @@ jobs:
     name: Inspect the code health
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install a flaked Nix
         uses: DeterminateSystems/nix-installer-action@v9
       - name: Install dependencies
@@ -30,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install a flaked Nix
         uses: DeterminateSystems/nix-installer-action@v9
       - name: Clean the environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include a note to update milestones after a release
 - Automatically extend the license at the start of a year
 - Use the development Nix flake in continuous integration
+- Checkout the entire Git history for automated testing
 
 ## [0.1.1] - 2024-01-15
 


### PR DESCRIPTION
### before

https://github.com/zimeg/emporia-time/actions/runs/7926632673/job/21641691201#step:5:9

```
$ nix develop -c make build
go build -o etime -ldflags "-X main.version="8a30831""
```