### PR TITLE
ci(fix): ignore temporary certificates for clean release signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Built binaries
-.gon.hcl
 etime
 dist/*
 
@@ -10,3 +9,7 @@ dist/*
 # Environment settings
 .direnv
 .env
+
+# Release artifacts
+.gon.hcl
+certificate.p12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore temporary certificates for clean release signing
+
 ## [1.0.0] - 2024-02-18
 
 ### Added


### PR DESCRIPTION
```
  ⨯ release failed after 3s                  error=git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? certificate.p12
```

https://github.com/zimeg/emporia-time/actions/runs/7948164757/job/21697874074#step:5:155