### PR TITLE
build: set the go version to a fixed 1.22.6 for the toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ to [Semantic Versioning][semver].
 
 - Include the manual pages as part of the release artifacts
 
+### Maintenance
+
+- Set the `go` version to a fixed `1.22.6` for the toolchain
+
 ## [1.1.0] - 2024-08-03
 
 ### Added

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719379843,
-        "narHash": "sha256-u+D+IOAMMl70+CJ9NKB+RMrASjInuIWMHzjLWQjPZ6c=",
+        "lastModified": 1725194671,
+        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3f3c1b13fb08f3828442ee86630362e81136bbc",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1719622426,
-        "narHash": "sha256-JKlnbirIWz9xSWCL4t/X883v6uxsefdfB9f264vr/7Y=",
+        "lastModified": 1722756065,
+        "narHash": "sha256-1ZirMrYEf6wrDbh9QyY08MPixKtpBTXIHjBej6BDnSU=",
         "owner": "zimeg",
         "repo": "nur-packages",
-        "rev": "19117897b342bf61be67f7ab35aedc2974c936c7",
+        "rev": "3ecfd0ffb635c6ae6355c03f361a4e1647b8d519",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zimeg/emporia-time
 
-go 1.22
+go 1.22.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
the @codeql bot suggests this needs to be fixed per requirement:

> Invalid Go toolchain version
>
> As of Go 1.21, toolchain versions [must use the 1.N.P syntax][1].
>
> 1.22 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.
>
> [1]: https://go.dev/doc/toolchain#version

unsure if @dependabot can assist with this but it can be an occasional task!