### PR TITLE
ci(fix): wait until tests pass before merging updates to dependencies

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,6 +16,20 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: "Monitor energy usage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+      - name: Wait for packag to succeed
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: "Post a notification"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
       - name: Merge requests from the kind dependabot
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,7 +23,7 @@ jobs:
           check-name: "Monitor energy usage"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
-      - name: Wait for packag to succeed
+      - name: Wait for packaging to pass
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning][semver].
 ### Maintenance
 
 - Write reminders for the steps involved in wiki page updates
+- Wait until tests pass before merging updates to dependencies
 
 ## [1.1.1] - 2024-09-08
 


### PR DESCRIPTION
the wonderful and kind @dependabot gets so excited 🙏 and merges 😳  before some of the tests 🔬 pass!

from a past pr:

<img width="660" alt="oop" src="https://github.com/user-attachments/assets/56ad589b-cf2c-4527-af50-ee54820d504e">
