### PR TITLE
ci: require the testing benchmarks complete with success

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,6 +10,7 @@ jobs:
     name: Merge automatic pull requests
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    timeout-minutes: 12
     steps:
       - name: Collect update metadata
         id: metadata
@@ -30,6 +31,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
+          allowed-conclusions: success
       - name: Wait for packaging to pass
         uses: lewagon/wait-on-check-action@v1.3.4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning][semver].
 - Write reminders for the steps involved in wiki page updates
 - Wait until tests pass before merging updates to dependencies
 - Find missing references that the above changes might expect
+- Check that upstream merges do not let dependencies skip test
 
 ## [1.1.1] - 2024-09-08
 


### PR DESCRIPTION
https://github.com/zimeg/emporia-time/pull/143 merged without passing the `tom` tests!


https://github.com/zimeg/emporia-time/actions/runs/12106092846/job/33751467243

```
Checks completed:
Monitor energy usage: completed (skipped)
```

notes: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
notes: https://github.com/lewagon/wait-on-check-action?tab=readme-ov-file#allowed-conclusions