### PR TITLE
fix: remove an extra percent sign from help page sureness example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning][semver].
 ### Fixed
 
 - Set the version of the latest flake builds to be unversioned
+- Remove an extra percent sign from help page sureness example
 
 ### Maintenance
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,7 @@ func Root(
 		fmt.Printf("%s\n", version)
 		return etime.CommandResult{}, nil
 	} else if flags.Help {
-		templates.PrintHelpMessage()
+		templates.PrintHelpMessage(os.Stderr)
 		return etime.CommandResult{}, nil
 	}
 	cfg, err := config.Load(ctx, cog, fs, req, flags)

--- a/internal/display/templates/help.go
+++ b/internal/display/templates/help.go
@@ -2,13 +2,13 @@ package templates
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"regexp"
 	"strings"
 )
 
 // PrintHelpMessage outputs an informative message for this program
-func PrintHelpMessage() {
+func PrintHelpMessage(out io.Writer) {
 	helpTemplate := `
 Measure the time and energy used while executing a command
 
@@ -39,7 +39,7 @@ Measure the time and energy used while executing a command
 {{ Bold "EXAMPLE" }}
   $ {{ CommandName }} sleep 12
          12.00 real         0.00 user         0.00 sys
-        922.63 joules      76.87 watts      100.0%% sure
+        922.63 joules      76.87 watts      100.0% sure
 
 `
 	if body, err := templateBuilder(helpTemplate, nil); err != nil {
@@ -47,8 +47,8 @@ Measure the time and energy used while executing a command
 		body = boldRegex.ReplaceAllString(helpTemplate, "$1")
 		commandNameRegex := regexp.MustCompile(`{{ CommandName }}`)
 		body = commandNameRegex.ReplaceAllString(body, "etime")
-		fmt.Fprint(os.Stderr, strings.TrimLeft(body, "\n"))
+		fmt.Fprint(out, strings.TrimLeft(body, "\n"))
 	} else {
-		fmt.Fprint(os.Stderr, strings.TrimLeft(body, "\n"))
+		fmt.Fprint(out, strings.TrimLeft(body, "\n"))
 	}
 }

--- a/internal/display/templates/help_test.go
+++ b/internal/display/templates/help_test.go
@@ -1,0 +1,62 @@
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintHelpMessage(t *testing.T) {
+	tests := map[string]struct {
+		expected []string
+	}{
+		"outputs the expected help message": {
+			expected: []string{
+				"Measure the time and energy used while executing a command",
+				"",
+				"\x1b[1mUSAGE\x1b[0m",
+				fmt.Sprintf("  %s [flags] <command> [args]", os.Args[0]),
+				"",
+				"\x1b[1mDESCRIPTION\x1b[0m",
+				"  flags    optional flags to provide this program",
+				"  command  the program to execute and measure",
+				"  args     optional arguments for the command",
+				"",
+				"\x1b[1mFLAGS\x1b[0m",
+				"  -h, --help           display this very informative message",
+				"  -p, --portable       output measurements on separate lines",
+				"  --device <string>    name or ID of the smart plug to measure",
+				"  --username <string>  account username for Emporia",
+				"  --password <string>  account password for Emporia",
+				"  --version            print the current version of this build",
+				"",
+				"\x1b[1mOUTPUT\x1b[0m",
+				"  Command output is printed as specified by the command",
+				"  Time and energy usage information is output to stderr",
+				"",
+				"  Time is counted with seconds and measured by the time command",
+				"  Usage is measured by the device and shown in joules and watts",
+				"  Sure is the ratio of received-to-expected measurements",
+				"",
+				"\x1b[1mEXAMPLE\x1b[0m",
+				fmt.Sprintf("  $ %s sleep 12", os.Args[0]),
+				"         12.00 real         0.00 user         0.00 sys",
+				"        922.63 joules      76.87 watts      100.0% sure",
+				"",
+				"",
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			buff := bytes.Buffer{}
+			PrintHelpMessage(&buff)
+			expected := strings.Join(tt.expected, "\n")
+			assert.Equal(t, expected, buff.String())
+		})
+	}
+}


### PR DESCRIPTION
```diff
  EXAMPLE
    $ ./etime sleep 12
           12.00 real         0.00 user         0.00 sys
-         922.63 joules      76.87 watts      100.0%% sure
+         922.63 joules      76.87 watts      100.0% sure
```