### PR TITLE
build: bump the go runtime version to version 1.24.1 when building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ to [Semantic Versioning][semver].
 - Upload test results to gather insights into possible flakes
 - Run tests after each push or workflow dispatch for sureness
 - Update development and release dependencies on some schedule
+- Bump the go runtime version to version 1.24.1 when building
 
 ## [1.1.1] - 2024-09-08
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zimeg/emporia-time
 
-go 1.22.6
+go 1.24.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
to avoid the automagic 🪄 🤖 

```
go 1.23.0

toolchain go1.24.1
```