### PR TITLE
build: replace deprecated goreleaser options with recommended inputs

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -34,7 +34,8 @@ builds:
         gon .gon.hcl
         '
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       etime_
       {{- .Summary }}_
@@ -45,7 +46,8 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 changelog:
   disable: true
 checksum:

--- a/.goreleaser.staging.yml
+++ b/.goreleaser.staging.yml
@@ -13,26 +13,7 @@ builds:
     goos:
       - linux
       - windows
-  - id: etime_macos
-    binary: etime_{{.Summary}}
-    goos:
       - darwin
-    hooks:
-      post: |-
-        sh -c '
-        cat > .gon.hcl << EOF
-        source = ["./dist/etime_macos_{{.Target}}/etime_{{.Summary}}"]
-        bundle_id = "net.o526.etime"
-        sign {
-          application_identity = "Developer ID Application: Ethan Garrett Zimbelman (SA8WRA75UN)"
-        }
-        dmg {
-          output_path = "./dist/etime_{{.Target}}_{{.Summary}}.dmg"
-          volume_name = "etime_{{.Target}}"
-        }
-        EOF
-        gon .gon.hcl
-        '
 archives:
   - formats:
       - tar.gz

--- a/.goreleaser.staging.yml
+++ b/.goreleaser.staging.yml
@@ -13,7 +13,26 @@ builds:
     goos:
       - linux
       - windows
+  - id: etime_macos
+    binary: etime_{{.Summary}}
+    goos:
       - darwin
+    hooks:
+      post: |-
+        sh -c '
+        cat > .gon.hcl << EOF
+        source = ["./dist/etime_macos_{{.Target}}/etime_{{.Summary}}"]
+        bundle_id = "net.o526.etime"
+        sign {
+          application_identity = "Developer ID Application: Ethan Garrett Zimbelman (SA8WRA75UN)"
+        }
+        dmg {
+          output_path = "./dist/etime_{{.Target}}_{{.Summary}}.dmg"
+          volume_name = "etime_{{.Target}}"
+        }
+        EOF
+        gon .gon.hcl
+        '
 archives:
   - formats:
       - tar.gz

--- a/.goreleaser.staging.yml
+++ b/.goreleaser.staging.yml
@@ -15,7 +15,8 @@ builds:
       - windows
       - darwin
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       etime_
       {{- .Summary }}_
@@ -26,7 +27,8 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 changelog:
   disable: true
 checksum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ to [Semantic Versioning][semver].
 - Run tests and packaging scripts again after automatic merges
 - Include the required token for starting the testing workflow
 - Request updates to dependencies at a much more frequent time
+- Remove deprecated options from packaging program for release
 
 ## [1.1.1] - 2024-09-08
 


### PR DESCRIPTION
👁️‍🗨️ https://github.com/zimeg/emporia-time/actions/runs/13915763163/job/38938449388#step:4:117

```
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```
