### PR TITLE
ci: sign releases for mac machines without configuration errors

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -20,7 +20,7 @@ builds:
     hooks:
       post: |-
         sh -c '
-        cat > .gon.hcl << EOF
+        cat > .gon.hcl <<EOF
         source = ["./dist/etime_macos_{{.Target}}/etime_{{.Summary}}"]
         bundle_id = "net.o526.etime"
         sign {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres
 to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Fixed
+
+- Sign releases for mac machines without configuration errors
+
 ## [1.1.2] - 2025-03-17
 
 ### Added


### PR DESCRIPTION
?

```
.gon.hcl:10,4-11,1: Invalid multi-line string; Quoted strings may not be split over multiple lines. To produce a multi-line string, either use the \n escape to represent a newline character or use the "heredoc" multi-line template syntax., and 2 other diagnostic(s)
```

https://github.com/zimeg/emporia-time/actions/runs/13916991493/job/38941721661#step:5:301