### PR TITLE
build: update golangci linter to version 2.0.0 in configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,17 @@
 # yaml-language-server: $schema=https://json.schemastore.org/golangci-lint.json
+version: "2"
 linters:
   enable:
     - gocyclo
+    - misspell
+  exclusions:
+    presets:
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: "ST1005:"
+formatters:
+  enable:
     - gofumpt
     - goimports
-    - misspell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres
 to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Maintenance
+
+- Update language linter configurations to the latest version
+
 ## [1.1.2] - 2025-03-17
 
 ### Added

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
+        "lastModified": 1743076231,
+        "narHash": "sha256-yQugdVfi316qUfqzN8JMaA2vixl+45GxNm4oUfXlbgw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "rev": "6c5963357f3c1c840201eda129a99d455074db04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
👾 https://golangci-lint.run/product/migration-guide/

fixes a broken `update` script

https://github.com/zimeg/emporia-time/actions/runs/14148150411/job/39638005806#step:5:9

```
golangci-lint run ./...
Error: can't load config: gofumpt is a formatter
Failed executing command with error: can't load config: gofumpt is a formatter
make: *** [Makefile:7: check] Error 3
```