### PR TITLE
build: make test coverage dashboards when running coverage commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning][semver].
 ### Maintenance
 
 - Update language linter configurations to the latest version
+- Make test coverage dashboards when running coverage commands
 
 ## [1.1.2] - 2025-03-17
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test: build
 coverage: build
 	mkdir -p coverage
 	go test -v 2>&1 -coverprofile=coverage/coverage.txt ./... | tee coverage/results.out
+	go tool cover -html coverage/coverage.txt -o coverage/coverage.html
 	go-junit-report -in coverage/results.out -set-exit-code > coverage/coverage.xml
 
 staging: clean


### PR DESCRIPTION
```
$ open coverage/coverage.html
```

👾 