### PR TITLE
fix: return exit codes after time command subshell measures usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,3 +69,11 @@ jobs:
           EMPORIA_DEVICE: ${{ secrets.EMPORIA_DEVICE }}
           EMPORIA_USERNAME: ${{ secrets.EMPORIA_USERNAME }}
           EMPORIA_PASSWORD: ${{ secrets.EMPORIA_PASSWORD }}
+      - name: Ends with an exit code
+        run: |
+          nix run .# dream
+          [ "$?" -ne 127 ] && exit 1 || true
+        env:
+          EMPORIA_DEVICE: ${{ secrets.EMPORIA_DEVICE }}
+          EMPORIA_USERNAME: ${{ secrets.EMPORIA_USERNAME }}
+          EMPORIA_PASSWORD: ${{ secrets.EMPORIA_PASSWORD }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
           nix run .# dream
           STATUS=$?
           echo $STATUS
-          [ "$STATUS" -ne 127 ] && exit 1 || true
+          [ "$STATUS" -eq 127 ] || exit 1
         env:
           EMPORIA_DEVICE: ${{ secrets.EMPORIA_DEVICE }}
           EMPORIA_USERNAME: ${{ secrets.EMPORIA_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,9 @@ jobs:
         run: |
           set +e
           nix run .# dream
-          [ "$?" -ne 127 ] && exit 1 || true
+          STATUS=$?
+          echo $STATUS
+          [ "$STATUS" -ne 127 ] && exit 1 || true
         env:
           EMPORIA_DEVICE: ${{ secrets.EMPORIA_DEVICE }}
           EMPORIA_USERNAME: ${{ secrets.EMPORIA_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,8 +69,9 @@ jobs:
           EMPORIA_DEVICE: ${{ secrets.EMPORIA_DEVICE }}
           EMPORIA_USERNAME: ${{ secrets.EMPORIA_USERNAME }}
           EMPORIA_PASSWORD: ${{ secrets.EMPORIA_PASSWORD }}
-      - name: Ends with an exit code
+      - name: End with an exit code
         run: |
+          set +e
           nix run .# dream
           [ "$?" -ne 127 ] && exit 1 || true
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     wrapcheck:
       ignore-sigs:
         - "func (github.com/stretchr/testify/mock.Arguments).Error(index int) error"
-        - "func (*os/exec.Cmd).Run() error"
 formatters:
   enable:
     - gofumpt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning][semver].
 
 - Output errors and related messages with charms logging print
 
+### Fixed
+
+- Return exit codes after time command subshell measures usage
+
 ### Maintenance
 
 - Update language linter configurations to the latest version

--- a/cmd/etime/etime.go
+++ b/cmd/etime/etime.go
@@ -1,8 +1,6 @@
 package etime
 
 import (
-	"os/exec"
-
 	"github.com/zimeg/emporia-time/internal/errors"
 	"github.com/zimeg/emporia-time/internal/logs"
 	"github.com/zimeg/emporia-time/pkg/config"
@@ -14,7 +12,6 @@ import (
 type CommandResult struct {
 	energy.EnergyResult
 	times.TimeMeasurement
-	ExitCode int
 }
 
 // Run executes the command and returns the usage statistics
@@ -34,13 +31,7 @@ func Run(
 	}
 	measurements, err := times.TimeExec(cmd, logger)
 	if err != nil {
-		exitError := &exec.ExitError{}
-		if errors.As(err, exitError) {
-			results.ExitCode = exitError.ExitCode()
-		} else {
-			return CommandResult{}, errors.Wrap(errors.ErrTimeExecution, err)
-		}
-		results.TimeMeasurement = measurements
+		return CommandResult{}, errors.Wrap(errors.ErrTimeExecution, err)
 	} else {
 		results.TimeMeasurement = measurements
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -38,6 +38,7 @@ const (
 	ErrTemplatePrint           errorCode = "err_template_print"
 	ErrTimeCommand             errorCode = "err_time_command"
 	ErrTimeExecution           errorCode = "err_time_execution"
+	ErrTimeParseCode           errorCode = "err_time_parse_code"
 	ErrTimeParseReal           errorCode = "err_time_parse_real"
 	ErrTimeParseSys            errorCode = "err_time_parse_sys"
 	ErrTimeParseUser           errorCode = "err_time_parse_user"
@@ -164,6 +165,9 @@ func New(code errorCode) (err Err) {
 		},
 		ErrTimeExecution: {
 			Message: "failed to execute time command",
+		},
+		ErrTimeParseCode: {
+			Message: "failed to parse exit code",
 		},
 		ErrTimeParseReal: {
 			Message: "failed to parse 'real' time",

--- a/main.go
+++ b/main.go
@@ -33,5 +33,5 @@ func main() {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	os.Exit(result.ExitCode)
+	os.Exit(result.Command.Code)
 }

--- a/pkg/times/stopwatch.go
+++ b/pkg/times/stopwatch.go
@@ -76,9 +76,6 @@ func timerCommand(command []string, stderr bufferWriter) *exec.Cmd {
 		strings.Join(timeShell, " "),
 	}
 	cmd := exec.Command(timer, timeArgs...)
-	if errors.Is(cmd.Err, exec.ErrDot) {
-		cmd.Err = nil
-	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stderr
 	return cmd

--- a/pkg/times/stopwatch_test.go
+++ b/pkg/times/stopwatch_test.go
@@ -31,6 +31,17 @@ func TestBufferWriter(t *testing.T) {
 				"information from the time",
 			},
 		},
+		"groups buffered output after bounds": {
+			bounds: "-",
+			output: []string{
+				"-details go here",
+				"and more might follow",
+			},
+			expectedBuff: []string{
+				"details go here",
+				"and more might follow",
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -83,7 +83,7 @@ func parseTimeResults(output string) (times CommandTime, errs []error) {
 		measurement, value := fields[0], fields[1]
 		switch measurement {
 		case "code":
-			parsed, err := strconv.ParseInt(value, 10, 64)
+			parsed, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {
 				errs = append(errs, errors.Wrap(errors.ErrTimeParseReal, err))
 			}

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -85,7 +85,7 @@ func parseTimeResults(output string) (times CommandTime, errs []error) {
 		case "code":
 			parsed, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {
-				errs = append(errs, errors.Wrap(errors.ErrTimeParseReal, err))
+				errs = append(errs, errors.Wrap(errors.ErrTimeParseCode, err))
 			}
 			times.Code = int(parsed)
 		case "real":

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -3,6 +3,7 @@ package times
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ type TimeMeasurement struct {
 
 // CommandTime contains the values from the time command
 type CommandTime struct {
+	Code int
 	Real float64
 	User float64
 	Sys  float64
@@ -60,7 +62,12 @@ func TimeExec(args []string, logger logs.Logger) (TimeMeasurement, error) {
 	times.Elapsed = times.End.Sub(times.Start)
 	times.Command = results
 	if err != nil {
-		return times, err
+		var exits *exec.ExitError
+		ok := errors.As(err, &exits)
+		if !ok {
+			return times, errors.Wrap(errors.ErrTimeCommand, err)
+		}
+		times.Command.Code = exits.ExitCode()
 	}
 	return times, nil
 }
@@ -75,6 +82,12 @@ func parseTimeResults(output string) (times CommandTime, errs []error) {
 		}
 		measurement, value := fields[0], fields[1]
 		switch measurement {
+		case "code":
+			parsed, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				errs = append(errs, errors.Wrap(errors.ErrTimeParseReal, err))
+			}
+			times.Code = int(parsed)
 		case "real":
 			parsed, err := strconv.ParseFloat(value, 64)
 			if err != nil {

--- a/pkg/times/time.go
+++ b/pkg/times/time.go
@@ -62,12 +62,12 @@ func TimeExec(args []string, logger logs.Logger) (TimeMeasurement, error) {
 	times.Elapsed = times.End.Sub(times.Start)
 	times.Command = results
 	if err != nil {
-		var exits *exec.ExitError
-		ok := errors.As(err, &exits)
+		var exitErr *exec.ExitError
+		ok := errors.As(err, &exitErr)
 		if !ok {
 			return times, errors.Wrap(errors.ErrTimeCommand, err)
 		}
-		times.Command.Code = exits.ExitCode()
+		times.Command.Code = exitErr.ExitCode()
 	}
 	return times, nil
 }

--- a/pkg/times/time_test.go
+++ b/pkg/times/time_test.go
@@ -17,11 +17,13 @@ func TestParseTimeResults(t *testing.T) {
 	}{
 		"parse the portable output of the time command": {
 			[]string{
+				"code 0",
 				"real 6.00",
 				"user 121.20",
 				"sys 0.80",
 			},
 			CommandTime{
+				Code: 0,
 				Real: 6.0,
 				User: 121.2,
 				Sys:  0.8,
@@ -30,11 +32,13 @@ func TestParseTimeResults(t *testing.T) {
 		},
 		"continues parsing even if one output errors": {
 			[]string{
+				"code 12",
 				"real 1.23",
 				"user ****",
 				"sys 90000",
 			},
 			CommandTime{
+				Code: 12,
 				Real: 1.23,
 				Sys:  90000,
 			},
@@ -46,12 +50,16 @@ func TestParseTimeResults(t *testing.T) {
 		},
 		"continues parsing even if all outputs error": {
 			[]string{
+				"code x",
 				"real ~6.00",
 				"user ~121.20",
 				"sys ~0.80",
 			},
 			CommandTime{},
 			[]error{
+				errors.Err{
+					Code: errors.ErrTimeParseCode,
+				},
 				errors.Err{
 					Code: errors.ErrTimeParseReal,
 				},


### PR DESCRIPTION
```
$ ./etime return -1
```


👁️