### PR TITLE
build: output flake build as shorter etime instead of project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning][semver].
 ### Fixed
 
 - Return exit codes after time command subshell measures usage
+- Output flake build as shorter etime instead of project name
 
 ### Maintenance
 

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
           ];
         };
         packages.default = pkgs.buildGoModule rec {
-          pname = "emporia-time";
+          pname = "etime";
           version = "unversioned";
           src = ./.;
           ldflags = [

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,10 @@
           ];
           doCheck = true;
           vendorHash = "sha256-smJr1p+FbEG65sfu7TWhpWtR8R8gKR6tRI+w/1dDdfs=";
+          installPhase = ''
+            mkdir -p $out/bin
+            mv $GOPATH/bin/emporia-time $out/bin/etime
+          '';
           meta = {
             description = "an energy aware time command";
             homepage = "https://github.com/zimeg/emporia-time";


### PR DESCRIPTION
❄️ ✨ 

```diff
  $ nix shell github:zimeg/emporia-time
- $ emporia-time sleep 12
+ $ etime sleep 12
```
