### PR TITLE
ci: reduce the set of permission required for the action runners

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,8 @@ jobs:
   happened:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/licensure.yml
+++ b/.github/workflows/licensure.yml
@@ -8,6 +8,9 @@ jobs:
   licensure:
     name: Extension for the year
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-permissions:
-  contents: write
 jobs:
   version:
     name: Collect the version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.tag.outputs.version }}
     steps:
@@ -32,6 +32,8 @@ jobs:
     needs: version
     if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       version: ${{ needs.version.outputs.version }}
     steps:
@@ -85,6 +87,8 @@ jobs:
       - snapshot
       - version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       version: ${{ needs.version.outputs.version }}
     strategy:
@@ -139,6 +143,8 @@ jobs:
     needs: version
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: macos-latest
+    permissions:
+      contents: write
     env:
       version: ${{ needs.version.outputs.version }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ jobs:
   checkup:
     name: Inspect the code health
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,6 +43,8 @@ jobs:
     name: Monitor energy usage
     needs: checkup
     runs-on: self-hosted
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning][semver].
 - Update language linter configurations to the latest version
 - Make test coverage dashboards when running coverage commands
 - Exit with success if updates to dependencies were not found
+- Reduce the set of permission required for the action runners
 
 ## [1.1.2] - 2025-03-17
 


### PR DESCRIPTION
🔐

- https://github.com/zimeg/emporia-time/security/code-scanning/2
- https://github.com/zimeg/emporia-time/security/code-scanning/3
- https://github.com/zimeg/emporia-time/security/code-scanning/4
- https://github.com/zimeg/emporia-time/security/code-scanning/5