### PR TITLE
ci: migrate nix-dependent workflows to self-hosted runners

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 12
     permissions:
       actions: write
@@ -33,9 +33,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        if: steps.metadata.outputs.package-ecosystem == 'go_modules'
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Update hashed dependencies
         if: steps.metadata.outputs.package-ecosystem == 'go_modules'
         run: |
@@ -129,7 +126,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: write
       contents: write
@@ -144,8 +141,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Update to the latest
         run: |
           nix flake update

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: self-hosted
+    runs-on: tom
     timeout-minutes: 12
     permissions:
       actions: write
@@ -126,7 +126,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,7 +145,7 @@ jobs:
     name: Distribute a release
     needs: version
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: self-hosted
+    runs-on: tim
     permissions:
       contents: write
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
     needs:
       - snapshot
       - version
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     name: Save a snapshot
     needs: version
     if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     env:
@@ -43,8 +43,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Create snapshots
         run: nix develop -c goreleaser release --clean --snapshot --skip=publish --config .goreleaser.staging.yaml
       - name: Mark logged changes
@@ -147,7 +145,7 @@ jobs:
     name: Distribute a release
     needs: version
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: macos-latest
+    runs-on: self-hosted
     permissions:
       contents: write
     env:
@@ -158,8 +156,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Create releases
         run: |
           nix develop .#tom -c sops exec-env vault.release.json 'goreleaser release --clean --config .goreleaser.release.yaml'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     name: Save a snapshot
     needs: version
     if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       contents: read
     env:
@@ -86,7 +86,7 @@ jobs:
     needs:
       - snapshot
       - version
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       contents: read
     env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   checkup:
     name: Inspect the code health
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -15,8 +15,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Install dependencies
         run: nix develop -c go get
       - name: Check formatting
@@ -54,13 +52,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Reflect existing Nix
-        id: nixos
-        continue-on-error: true
-        run: uname -a | grep NixOS
-      - name: Install a flaked Nix
-        if: steps.nixos.outcome != 'success'
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Clean the environment
         run: nix develop -c make clean
       - name: Sleep for a short while

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,11 +23,17 @@ jobs:
         run: nix develop -c make build
       - name: Run tests
         run: nix develop -c make coverage
+      - name: Locate Codecov
+        id: codecov
+        run: echo "binary=$(command -v codecovcli)" >> "$GITHUB_OUTPUT"
       - name: Upload coverage results
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
+          binary: ${{ steps.codecov.outputs.binary }}
           disable_search: true
           files: coverage/coverage.txt
+          override_commit: ${{ github.sha }}
+          slug: ${{ github.repository }}
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
           verbose: true
@@ -35,8 +41,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
+          binary: ${{ steps.codecov.outputs.binary }}
           disable_search: true
           files: coverage/coverage.xml
+          override_commit: ${{ github.sha }}
+          slug: ${{ github.repository }}
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
           verbose: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   checkup:
     name: Inspect the code health
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       contents: read
     steps:
@@ -52,7 +52,7 @@ jobs:
   measurement:
     name: Monitor energy usage
     needs: checkup
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       contents: read
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning][semver].
 ## [Unreleased]
 
 ### Maintenance
+- Migrate nix dependent workflows to use self hosted runner machines
 
 - Group updates to the authentication configuration providers
 - Use variables in function return statements to be more clear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ to [Semantic Versioning][semver].
 ## [Unreleased]
 
 ### Maintenance
-- Migrate nix dependent workflows to use self hosted runner machines
 
 - Group updates to the authentication configuration providers
 - Use variables in function return statements to be more clear
@@ -17,6 +16,7 @@ to [Semantic Versioning][semver].
 - Remove prior indirect dependencies after updating packaging
 - Replace a deprecated test result measurement with the recent
 - Detect the host platform for nix builds with current tooling
+- Package releases and other checks on managed infrastructure
 
 ## [1.1.3] - 2025-08-16
 


### PR DESCRIPTION
Switches nix-dependent jobs to self-hosted runners and removes the DeterminateSystems nix-installer-action setup step. Changelog, licensure, and non-nix release jobs stay on ubuntu-latest.