### PR TITLE
chore(ci): move nix jobs to self-hosted runners

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 12
     permissions:
       actions: write
@@ -33,9 +33,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        if: steps.metadata.outputs.package-ecosystem == 'go_modules'
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Update hashed dependencies
         if: steps.metadata.outputs.package-ecosystem == 'go_modules'
         run: |
@@ -129,7 +126,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: write
       contents: write
@@ -144,8 +141,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Update to the latest
         run: |
           nix flake update

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     name: Save a snapshot
     needs: version
     if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     env:
@@ -43,8 +43,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Create snapshots
         run: nix develop -c goreleaser release --clean --snapshot --skip=publish --config .goreleaser.staging.yaml
       - name: Mark logged changes
@@ -147,7 +145,9 @@ jobs:
     name: Distribute a release
     needs: version
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: macos-latest
+    runs-on:
+      - self-hosted
+      - macOS
     permissions:
       contents: write
     env:
@@ -158,8 +158,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Create releases
         run: |
           nix develop .#tom -c sops exec-env vault.release.json 'goreleaser release --clean --config .goreleaser.release.yaml'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   checkup:
     name: Inspect the code health
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -15,8 +15,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Install dependencies
         run: nix develop -c go get
       - name: Check formatting
@@ -54,13 +52,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Reflect existing Nix
-        id: nixos
-        continue-on-error: true
-        run: uname -a | grep NixOS
-      - name: Install a flaked Nix
-        if: steps.nixos.outcome != 'success'
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Clean the environment
         run: nix develop -c make clean
       - name: Sleep for a short while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning][semver].
 ### Maintenance
 
 - Group updates to the authentication configuration providers
+- Run Nix-based automation on self-hosted runners without installer setup
 - Use variables in function return statements to be more clear
 - Update indirect dependencies alongside latest package change
 - Avoid erroring test retries with repeated packaging updates


### PR DESCRIPTION
## Summary
- move Nix-based jobs from `ubuntu-latest`/`macos-latest` onto self-hosted runners
- remove `DeterminateSystems/nix-installer-action` from those jobs
- keep lightweight non-Nix jobs on hosted runners

## Notes
This follows the self-hosted runner migration pattern while leaving jobs like changelog/licensure/other non-Nix checks on hosted runners.