### PR TITLE
ci: test updates inline to avoid overhead of multiple pending runner at once

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -153,6 +153,10 @@ jobs:
           [ "$STATUS" -eq 127 ] || exit 1
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_TESTING_KEY }}
+      - name: Save a snapshot
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          nix develop -c goreleaser release --clean --snapshot --skip=publish --config .goreleaser.staging.yaml
       - name: Save changed version
         if: steps.diff.outputs.changed == 'true'
         run: |

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -48,53 +48,26 @@ jobs:
           git push -u origin "$GH_REF"
         env:
           GH_REF: ${{ github.head_ref }}
-      - name: Start the tests
+      - name: Inspect the code health
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$GH_REPO/actions/workflows/tests.yaml/dispatches" \
-             -f "ref=$GH_REF"
-        env:
-          GH_REF: ${{ github.head_ref }}
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-      - name: Take a snapshot
+          nix develop -c go get
+          nix develop -c make check
+          nix develop -c make build
+          nix develop -c make coverage
+      - name: Monitor energy usage
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$GH_REPO/actions/workflows/release.yaml/dispatches" \
-             -f "ref=$GH_REF"
+          nix develop .#tom -c sops exec-env vault.testing.json 'nix run .# sleep 4'
+          nix develop .#tom -c sops exec-env vault.testing.json 'nix run .# sleep 12'
+          set +e
+          nix develop .#tom -c sops exec-env vault.testing.json 'nix run .# dream'
+          STATUS=$?
+          echo $STATUS
+          [ "$STATUS" -eq 127 ] || exit 1
         env:
-          GH_REF: ${{ github.head_ref }}
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          check-name: "Inspect the code health"
-          ref: ${{ github.head_ref }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-      - name: Wait for a testing benchmark
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          check-name: "Monitor energy usage"
-          ref: ${{ github.head_ref }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
-      - name: Wait for packaging to pass
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          check-name: "Save a snapshot"
-          ref: ${{ github.head_ref }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_TESTING_KEY }}
+      - name: Save a snapshot
+        run: |
+          nix develop -c goreleaser release --clean --snapshot --skip=publish --config .goreleaser.staging.yaml
       - name: Merge requests from the kind dependabot
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
@@ -161,35 +134,25 @@ jobs:
           git switch --force-create update origin/main
           git commit --all --message "chore(deps): automatic version bump to the most recent packages"
           git push -f origin update
-      - name: Start the tests
+      - name: Inspect the code health
         if: steps.diff.outputs.changed == 'true'
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$GH_REPO/actions/workflows/tests.yaml/dispatches" \
-             -f "ref=update"
+          nix develop -c go get
+          nix develop -c make check
+          nix develop -c make build
+          nix develop -c make coverage
+      - name: Monitor energy usage
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          nix develop .#tom -c sops exec-env vault.testing.json 'nix run .# sleep 4'
+          nix develop .#tom -c sops exec-env vault.testing.json 'nix run .# sleep 12'
+          set +e
+          nix develop .#tom -c sops exec-env vault.testing.json 'nix run .# dream'
+          STATUS=$?
+          echo $STATUS
+          [ "$STATUS" -eq 127 ] || exit 1
         env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-      - name: Wait for tests to succeed
-        if: steps.diff.outputs.changed == 'true'
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          check-name: "Inspect the code health"
-          ref: update
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-      - name: Wait for a testing benchmark
-        if: steps.diff.outputs.changed == 'true'
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          check-regexp: "Monitor energy usage"
-          ref: update
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_TESTING_KEY }}
       - name: Save changed version
         if: steps.diff.outputs.changed == 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ to [Semantic Versioning][semver].
 
 ### Maintenance
 
-- Test dependency updates inline to avoid overhead of multiple pending runner at once.
 - Group updates to the authentication configuration providers
 - Use variables in function return statements to be more clear
 - Update indirect dependencies alongside latest package change
@@ -18,6 +17,7 @@ to [Semantic Versioning][semver].
 - Replace a deprecated test result measurement with the recent
 - Detect the host platform for nix builds with current tooling
 - Package releases and other checks on managed infrastructure
+- Test updates to dependencies inline to avoid multiple runner
 
 ## [1.1.3] - 2025-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning][semver].
 
 ### Maintenance
 
+- Test dependency updates inline to avoid overhead of multiple pending runner at once.
 - Group updates to the authentication configuration providers
 - Use variables in function return statements to be more clear
 - Update indirect dependencies alongside latest package change


### PR DESCRIPTION
The `lewagon/wait-on-check-action` composite action uses `ruby/setup-ruby` internally, which fails on the self-hosted NixOS runner.

This replaces the dependency workflow's dispatch-and-wait pattern with direct inline execution, so dependency update validation happens in the same workflow instead of spawning extra pending runs.