### PR TITLE
ci: guard notification comments against fork pull request events

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,12 +121,15 @@ jobs:
   notify:
     name: Post a notification
     needs: artifacts
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: Leave a comment
+        continue-on-error: true
         run: |
           PR_COMMENT="Latest builds: https://github.com/$GH_REPO/actions/runs/$GH_RUN_ID"
           PR_REF="$GH_REF"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ to [Semantic Versioning][semver].
 - Detect the host platform for nix builds with current tooling
 - Package releases and other checks on managed infrastructure
 - Test updates to dependencies inline to avoid multiple runner
+- Guard notification comments against fork pull request events
 
 ## [1.1.3] - 2025-08-16
 


### PR DESCRIPTION
Adds two guards to the "Post a notification" job:

1. **Fork PR check** — skips the job entirely for fork PRs where `GITHUB_TOKEN` lacks write permissions on the base repo
2. **continue-on-error** — prevents a failed comment from marking the whole workflow as failed

Changes the `if` condition from:
```yaml
if: github.event_name == 'pull_request'
```
to:
```yaml
if: >-
  github.event_name == 'pull_request' &&
  github.event.pull_request.head.repo.full_name == github.repository
```