### PR TITLE
ci: checkout code before test updates to ci script dependencies

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Checkout this repo
-        if: steps.metadata.outputs.package-ecosystem == 'go_modules'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ to [Semantic Versioning][semver].
 - Detect the host platform for nix builds with current tooling
 - Package releases and other checks on managed infrastructure
 - Test updates to dependencies inline to avoid multiple runner
+- Checkout code before test updates to CI script dependencies
 
 ## [1.1.3] - 2025-08-16
 


### PR DESCRIPTION
🔗 #308 - https://github.com/zimeg/emporia-time/actions/runs/26704418436/job/78702874774?pr=308#step:6:10

```
Run nix develop -c go get
path '/run/github-runner/etime-positive/emporia-time/emporia-time' does not contain a 'flake.nix', searching up
error: could not find a flake.nix file
```